### PR TITLE
"Add Result controller with endpoints for vote statistics

### DIFF
--- a/SurveyBasket/SurveyBasket.API/Controllers/ResultsController.cs
+++ b/SurveyBasket/SurveyBasket.API/Controllers/ResultsController.cs
@@ -1,0 +1,39 @@
+﻿
+namespace SurveyBasket.API.Controllers;
+[Route("api/Polls/{pollId}/[controller]")]
+[ApiController]
+[Authorize]
+public class ResultsController(IResultService resultService) : ControllerBase
+{
+    private readonly IResultService _resultService = resultService;
+
+    [HttpGet("row-data")] //api/Polls/1/results/row-data
+    public async Task<IActionResult> PollVotes([FromRoute] int pollId ,CancellationToken cancellationToken)
+    {
+        var result = await _resultService.GetPollVotesAsync(pollId, cancellationToken);
+
+        return result.IsSuccess ? Ok(result.Value) : result.ToProblem();
+    }
+
+
+    [HttpGet("votes-per-day")] //api/Polls/1/results/votes-per-day
+    public async Task<IActionResult> VotesPerDay([FromRoute] int pollId, CancellationToken cancellationToken)
+    {
+        var result = await _resultService.GetVotesPerDayAsync(pollId, cancellationToken);
+
+        return result.IsSuccess ? Ok(result.Value) : result.ToProblem();
+    }
+
+
+    [HttpGet("votes-per-question")] //api/Polls/1/results/votes-per-question
+    public async Task<IActionResult> VotesPerQuestion([FromRoute] int pollId, CancellationToken cancellationToken)
+    {
+        var result = await _resultService.GetVotesPerQuestionAsync(pollId, cancellationToken);
+
+        return result.IsSuccess ? Ok(result.Value) : result.ToProblem();
+    }
+
+
+
+
+}

--- a/SurveyBasket/SurveyBasket.Application/GlobalUsings.cs
+++ b/SurveyBasket/SurveyBasket.Application/GlobalUsings.cs
@@ -2,3 +2,4 @@
 global using  SurveyBasket.Contracts.Authentication;
 global using SurveyBasket.Domain.Abstractions;
 global using SurveyBasket.Contracts.Polls;
+global using SurveyBasket.Contracts.Results;

--- a/SurveyBasket/SurveyBasket.Application/Services/IResultService.cs
+++ b/SurveyBasket/SurveyBasket.Application/Services/IResultService.cs
@@ -1,0 +1,10 @@
+﻿
+
+namespace SurveyBasket.Application.Services;
+public interface IResultService
+{
+    Task<Result<PollVotesResponse>> GetPollVotesAsync(int pollId, CancellationToken cancellationToken = default);
+    Task<Result<IEnumerable<VotePerDayResponse>>> GetVotesPerDayAsync(int pollId, CancellationToken cancellationToken = default);
+
+    Task<Result<IEnumerable<VotesPerQuestionResponse>>> GetVotesPerQuestionAsync(int pollId, CancellationToken cancellationToken = default);
+}

--- a/SurveyBasket/SurveyBasket.Contracts/Results/PollVotesResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/PollVotesResponse.cs
@@ -1,0 +1,4 @@
+﻿
+namespace SurveyBasket.Contracts.Results;
+public record PollVotesResponse(string Title , IEnumerable<VoteResponse> Votes);
+

--- a/SurveyBasket/SurveyBasket.Contracts/Results/QuestionAnswerResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/QuestionAnswerResponse.cs
@@ -1,0 +1,4 @@
+﻿
+namespace SurveyBasket.Contracts.Results;
+public record QuestionAnswerResponse(string Question,string Answer);
+

--- a/SurveyBasket/SurveyBasket.Contracts/Results/VotePerDayResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/VotePerDayResponse.cs
@@ -1,0 +1,5 @@
+﻿
+
+namespace SurveyBasket.Contracts.Results;
+public record VotePerDayResponse(DateOnly Date , int NumberOfVotes);
+

--- a/SurveyBasket/SurveyBasket.Contracts/Results/VoteResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/VoteResponse.cs
@@ -1,0 +1,4 @@
+﻿
+namespace SurveyBasket.Contracts.Results;
+public record VoteResponse(string VoterName ,DateTime VoteDate , IEnumerable<QuestionAnswerResponse> SelectedAnswers);
+

--- a/SurveyBasket/SurveyBasket.Contracts/Results/VotesPerAnswerResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/VotesPerAnswerResponse.cs
@@ -1,0 +1,4 @@
+﻿
+namespace SurveyBasket.Contracts.Results;
+public record VotesPerAnswerResponse(string Answer ,int Count);
+

--- a/SurveyBasket/SurveyBasket.Contracts/Results/VotesPerQuestionResponse.cs
+++ b/SurveyBasket/SurveyBasket.Contracts/Results/VotesPerQuestionResponse.cs
@@ -1,0 +1,5 @@
+﻿
+
+namespace SurveyBasket.Contracts.Results;
+public record VotesPerQuestionResponse(string Question ,IEnumerable<VotesPerAnswerResponse> SeelctedAnswer);
+

--- a/SurveyBasket/SurveyBasket.Domain/Entities/Question.cs
+++ b/SurveyBasket/SurveyBasket.Domain/Entities/Question.cs
@@ -12,4 +12,5 @@ public sealed class Question:AuditableEntity
     public Poll Poll { get; set; } = default!;
 
     public ICollection<Answer> Answers { get; set; } = [];
+    public ICollection<VoteAnswer> VoteAnswers { get; set; } = [];
 }

--- a/SurveyBasket/SurveyBasket.Infrastruction/ConfigureServices/InfrastructureServices.cs
+++ b/SurveyBasket/SurveyBasket.Infrastruction/ConfigureServices/InfrastructureServices.cs
@@ -31,6 +31,12 @@ public static class InfrastructureServices
 
         #endregion
 
+        #region Result
+
+        services.AddScoped<IResultService, ResultService>();
+
+        #endregion
+
         #region Identity
 
         services.AddIdentity<ApplicationUser, IdentityRole>()

--- a/SurveyBasket/SurveyBasket.Infrastruction/GlobalUsings.cs
+++ b/SurveyBasket/SurveyBasket.Infrastruction/GlobalUsings.cs
@@ -25,5 +25,6 @@ global using System.Security.Cryptography;
 global using Mapster;
 
 global using SurveyBasket.Contracts.Polls;
+global using SurveyBasket.Contracts.Results;
 
 

--- a/SurveyBasket/SurveyBasket.Infrastruction/Implementations/ResultService.cs
+++ b/SurveyBasket/SurveyBasket.Infrastruction/Implementations/ResultService.cs
@@ -1,0 +1,96 @@
+﻿
+using System.Collections.Generic;
+
+namespace SurveyBasket.Infrastruction.Implementations;
+internal class ResultService(ApplicationDbContext context) : IResultService
+{
+    private readonly ApplicationDbContext _context = context;
+
+    public async Task<Result<PollVotesResponse>> GetPollVotesAsync(int pollId, CancellationToken cancellationToken)
+    {
+        var pollVotes = await _context.Polls
+            .Where(p => p.Id == pollId)
+            .Select(x => new PollVotesResponse(
+              x.Title,
+              x.Votes.Select(v => new VoteResponse(
+                 $"{v.User.FirstName} {v.User.LastName}",
+                 v.SubmittedOn,
+                 v.VoteAnswers.Select(a => new QuestionAnswerResponse(
+                   a.Question.Content,
+                   a.Answer.Content
+                 ))
+              ))
+            )).SingleOrDefaultAsync(cancellationToken);
+
+        return pollVotes is null
+            ? Result.Failure<PollVotesResponse>(PollErrors.PollNotFound)
+            : Result.Success(pollVotes);
+
+    }
+
+    public async Task<Result<IEnumerable<VotePerDayResponse>>> GetVotesPerDayAsync(int pollId, CancellationToken cancellationToken)
+    {
+        var pollIsExsits = await PollIsExsits(pollId, cancellationToken);
+
+        if (!pollIsExsits)
+            return Result.Failure< IEnumerable<VotePerDayResponse>>(PollErrors.PollNotFound);
+
+        var votesPerDay = await _context.Votes.Where(v => v.PollId == pollId)
+            .GroupBy(vote =>
+                          new { Date = DateOnly.FromDateTime(vote.SubmittedOn) }
+            )
+            .Select(g => new VotePerDayResponse
+            ( 
+                g.Key.Date,
+                g.Count()
+            ))
+            .ToListAsync(cancellationToken);
+
+        return Result.Success<IEnumerable<VotePerDayResponse>>(votesPerDay);
+    }
+
+    public async Task<Result<IEnumerable<VotesPerQuestionResponse>>> GetVotesPerQuestionAsync(int pollId, CancellationToken cancellationToken)
+    {
+        var pollIsExsits = await PollIsExsits(pollId, cancellationToken);
+
+        if (!pollIsExsits)
+            return Result.Failure<IEnumerable<VotesPerQuestionResponse>>(PollErrors.PollNotFound);
+
+
+
+        var votesPerQuestion = await _context.VoteAnswers
+            .Where(x => x.Vote.PollId == pollId)
+
+            .Select(x => new VotesPerQuestionResponse
+            (
+                x.Question.Content,
+                x.Question.VoteAnswers
+
+                .GroupBy
+                (
+                    x => new { AnswerId = x.Answer.Id, AnswerContent = x.Answer.Content }
+                )
+                .Select
+                (
+                    g => new VotesPerAnswerResponse
+                    (
+                        g.Key.AnswerContent,
+                        g.Count()
+                    )
+                )
+
+            )
+
+            ).ToListAsync(cancellationToken);
+
+
+        return Result.Success<IEnumerable<VotesPerQuestionResponse>>(votesPerQuestion);
+
+    }
+
+
+    private async Task<bool> PollIsExsits(int pollId, CancellationToken cancellationToken =default)
+    {
+        return await _context.Polls.AnyAsync(p => p.Id == pollId, cancellationToken);
+    }
+}


### PR DESCRIPTION
- Added `ResultController` to handle vote-related statistics.
- Implemented endpoint `votes-per-question` to fetch votes per question.
- Implemented endpoint `votes-per-day` to fetch votes per day.
- Implemented endpoint `row-data` to fetch raw vote data.
- Updated routing to include new endpoints.

These endpoints are designed to provide detailed vote statistics for analysis purposes."